### PR TITLE
Add trim to remove whitespaces at validations 

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -29,7 +29,7 @@ class App extends Component {
     e.preventDefault();
     try {
       if (this.state.main) {
-        prompt("Copy your main key", toPrivateKey(this.state.main));
+        prompt("Copy your main key", toPrivateKey(this.state.main.trim()));
       }
     } catch (err) {
       alert("Error: Your main passphrase was wrong");
@@ -37,7 +37,7 @@ class App extends Component {
     }
     try {
       if (this.state.backup) {
-        prompt("Copy your backup key", toPrivateKey(this.state.backup));
+        prompt("Copy your backup key", toPrivateKey(this.state.backup.trim()));
       }
     } catch (err) {
       alert("Error: Your backup passphrase was wrong");


### PR DESCRIPTION
Even if correct key was entered with extra space it showed error, that was fixed by adding .trim()